### PR TITLE
Rename (and NewAPI)

### DIFF
--- a/kinova_driver/include/kinova_driver/jaco_comm.h
+++ b/kinova_driver/include/kinova_driver/jaco_comm.h
@@ -93,8 +93,10 @@ class JacoComm
     void stopAPI();
     void startAPI();
     bool isStopped();
-    int numFingers();
-    int robotType();
+    int numFingers() const;
+    int robotType() const;
+
+    double j6o() const; // Joint 6 offset (second wrist part) that differs between models.
 
     void setEndEffectorOffset(float x, float y, float z);
 

--- a/kinova_driver/include/kinova_driver/jaco_types.h
+++ b/kinova_driver/include/kinova_driver/jaco_types.h
@@ -91,10 +91,10 @@ class JacoAngles : public AngularInfo
 {
  public:
     JacoAngles() {}
-    explicit JacoAngles(const kinova_msgs::JointAngles &angles);
+    explicit JacoAngles(const kinova_msgs::JointAngles &angles, double j6o);
     explicit JacoAngles(const AngularInfo &angles);
 
-    kinova_msgs::JointAngles constructAnglesMsg();
+    kinova_msgs::JointAngles constructAnglesMsg(double j6o);
     bool isCloseToOther(const JacoAngles &, float tolerance) const;
 };
 

--- a/kinova_driver/src/jaco_arm.cpp
+++ b/kinova_driver/src/jaco_arm.cpp
@@ -319,13 +319,15 @@ void JacoArm::jointVelocityTimer(const ros::TimerEvent&)
  */
 void JacoArm::publishJointAngles(void)
 {
+    double j6o = jaco_comm_.j6o();
+
     FingerAngles fingers;
     jaco_comm_.getFingerPositions(fingers);
 
     // Query arm for current joint angles
     JacoAngles current_angles;
     jaco_comm_.getJointAngles(current_angles);
-    kinova_msgs::JointAngles jaco_angles = current_angles.constructAnglesMsg();
+    kinova_msgs::JointAngles jaco_angles = current_angles.constructAnglesMsg(j6o);
 
     jaco_angles.joint1 = current_angles.Actuator1;
     jaco_angles.joint2 = current_angles.Actuator2;
@@ -341,8 +343,6 @@ void JacoArm::publishJointAngles(void)
     // Transform from Kinova DH algorithm to physical angles in radians, then place into vector array
     joint_state.position.resize(9);
 
-    // J6 offset is 260 for Jaco R1 (type 0), and 270 for Mico and Jaco R2.
-    double j6o = jaco_comm_.robotType() == 0 ? 260.0 : 270.0;
     joint_state.position[0] = (180- jaco_angles.joint1) * (PI / 180);
     joint_state.position[1] = (jaco_angles.joint2 - 270) * (PI / 180);
     joint_state.position[2] = (90-jaco_angles.joint3) * (PI / 180);

--- a/kinova_driver/src/jaco_comm.cpp
+++ b/kinova_driver/src/jaco_comm.cpp
@@ -122,24 +122,23 @@ JacoComm::JacoComm(const ros::NodeHandle& node_handle,
             getQuickStatus(quick_status);
 
             robot_type_ = quick_status.RobotType;
-            if ((robot_type_ != 0) && (robot_type_ != 1) && (robot_type_ != 3))
-            {
-                ROS_ERROR("Could not get the type of the arm from the quick status, expected "
-                          "either type 0 (JACO), or type 1 (MICO), got %d", quick_status.RobotType);
-                throw JacoCommException("Could not get the type of the arm", quick_status.RobotType);
-            }
-
             switch (robot_type_) {
                 case 0:
                 case 3:
+                case 4:
+                case 6:
                     num_fingers_ = 3;
                     break;
                 case 1:
+                case 2:
+                case 5:
                     num_fingers_ = 2;
                     break;
                 default:
+                    ROS_ERROR("Unknown robot type: %d", quick_status.RobotType);
+                    throw JacoCommException("Could not recognize the type of the arm", quick_status.RobotType);
                     break;
-            }
+            };
 
             ROS_INFO_STREAM("Found " << devices_count << " device(s), using device at index " << device_i
                             << " (model: " << configuration.Model

--- a/kinova_driver/src/jaco_comm.cpp
+++ b/kinova_driver/src/jaco_comm.cpp
@@ -781,12 +781,12 @@ void JacoComm::startAPI()
 }
 
 
-int JacoComm::numFingers()
+int JacoComm::numFingers() const
 {
     return num_fingers_;
 }
 
-int JacoComm::robotType()
+int JacoComm::robotType() const
 {
     return robot_type_;
 }
@@ -857,5 +857,10 @@ bool JacoComm::isStopped()
     return is_software_stop_;
 }
 
+double JacoComm::j6o() const
+{
+    // J6 offset is 260 for Jaco R1 (type 0), and 270 for Mico and Jaco R2.
+    return robotType() == 0 ? 260.0 : 270.0;
+}
 
 }  // namespace kinova

--- a/kinova_driver/src/jaco_types.cpp
+++ b/kinova_driver/src/jaco_types.cpp
@@ -192,14 +192,14 @@ bool JacoPose::isCloseToOther(const JacoPose &other, float tolerance) const
 }
 
 
-JacoAngles::JacoAngles(const kinova_msgs::JointAngles &angles)
+JacoAngles::JacoAngles(const kinova_msgs::JointAngles &angles, double j6o)
 {
     Actuator1 = normalizePositiveInDegrees(180.0 - (angles.joint1 * (180.0 / M_PI)));
     Actuator2 = normalizePositiveInDegrees((angles.joint2 * (180.0 / M_PI)) + 270.0);
     Actuator3 = normalizePositiveInDegrees(90.0 - (angles.joint3 * (180.0 / M_PI)));
     Actuator4 = normalizePositiveInDegrees(180.0 - (angles.joint4 * (180.0 / M_PI)));
     Actuator5 = normalizePositiveInDegrees(180.0 - (angles.joint5 * (180.0 / M_PI)));
-    Actuator6 = normalizePositiveInDegrees(260.0 - (angles.joint6 * (180.0 / M_PI)));
+    Actuator6 = normalizePositiveInDegrees(j6o   - (angles.joint6 * (180.0 / M_PI)));
 }
 
 
@@ -214,7 +214,7 @@ JacoAngles::JacoAngles(const AngularInfo &angles)
 }
 
 
-kinova_msgs::JointAngles JacoAngles::constructAnglesMsg()
+kinova_msgs::JointAngles JacoAngles::constructAnglesMsg(double j6o)
 {
     kinova_msgs::JointAngles angles;
     angles.joint1 = (180.0 - Actuator1) / (180.0 / M_PI);
@@ -222,7 +222,7 @@ kinova_msgs::JointAngles JacoAngles::constructAnglesMsg()
     angles.joint3 = (90.0 - Actuator3) / (180.0 / M_PI);
     angles.joint4 = (180.0 - Actuator4) / (180.0 / M_PI);
     angles.joint5 = (180.0 - Actuator5) / (180.0 / M_PI);
-    angles.joint6 = (260.0 - Actuator6) / (180.0 / M_PI);
+    angles.joint6 = (j6o   - Actuator6) / (180.0 / M_PI);
     return angles;
 }
 


### PR DESCRIPTION
Kinova is moving forward. Now we have Jaco and Mico arms, and there will be more products coming up soon. The ROS package originally developed for Jaco arm (**Jaco-ROS**) on current master branch, does not satisfy this expansion.  Further development based on Jaco-ROS for Mico arm already shows its limitation. The inappropriate notation deteriorates the code framework and confuses developers&users as well. Therefore, we are re-factoring the code to support better our current and future products(**Kinova-ROS**). The re-factoring starts with a renaming of current code (namespace, class, function, etc.) while keeping the same structure and content. Later on, the structure and content will be modified to provide a general framework with different robot model as one of the input parameters.

Meanwhile, the master branch of Jaco-ROS will be saved as a new branch with name "Jaco-ROS". Developers can still use  Jaco-ROS to develop their own applications and run for Jaco and Mico. However, new features update / request merge will be available only on Kinova-ROS.